### PR TITLE
Add build time and commit hash info to docker image

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,6 +6,8 @@ env:
   TEST_TAG: image-test
   PICT_VERSION: 3.7.4
   REVISION: ${{ inputs.ref || github.head_ref || github.ref_name }}
+  COMMIT_HASH: ${{ github.sha }}
+  BUILD_TIME: ${{ github.event.head_commit.timestamp }}
 
 jobs:
   docker:
@@ -36,15 +38,24 @@ jobs:
           docker run --rm ${{ env.TEST_TAG }} pict | grep "Pairwise Independent Combinatorial Testing"
       - name: Build and push feature branch
         if: github.ref != 'refs/heads/main'
+        env:
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+          BUILD_TIME: ${{ env.BUILD_TIME }}
         uses: docker/build-push-action@v3
         with:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
             renfis/pict:feature-${{ env.REVISION }}
+          build-args: |
+            COMMIT_HASH=${{ env.COMMIT_HASH }}
+            BUILD_TIME=${{ env.BUILD_TIME }}
       -
         name: Build and push main
         if: github.ref == 'refs/heads/main'
+        env:
+          COMMIT_HASH: ${{ env.COMMIT_HASH }}
+          BUILD_TIME: ${{ env.BUILD_TIME }}
         uses: docker/build-push-action@v3
         with:
           push: true
@@ -52,3 +63,6 @@ jobs:
           tags: |
             renfis/pict:latest
             renfis/pict:${{ env.PICT_VERSION }}
+          build-args: |
+            COMMIT_HASH=${{ env.COMMIT_HASH }}
+            BUILD_TIME=${{ env.BUILD_TIME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,12 @@ FROM ubuntu:23.04
 COPY --from=pict-builder --chown=1001:root /pict/pict /usr/local/bin/pict
 COPY --from=quarkus-builder --chown=1001:root /workspace/target/pict-1.0.0-SNAPSHOT-runner /usr/local/bin/app
 
+ARG COMMIT_HASH
+ARG BUILD_TIME
+
+ENV COMMIT_HASH=$COMMIT_HASH
+ENV BUILD_TIME=$BUILD_TIME
+
 EXPOSE 8080
 USER 1001
 


### PR DESCRIPTION
Problem:
We can't see only from the build tag which application version is currently deployed. We want to provide this information in a health check. Also the Pict version should not be hardcoded in the html.

Solution:
As a first step provide the build time and the commit hash as docker environment variables. By inspecting the image, we see which version is currently running.
In a next step we will read these values in the Java code and provide the information to the frontend.